### PR TITLE
cargo fmt, handle errors, fix tuples with 1 item

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["full", "visit-mut"] }
 quote = "1.0"
+proc-macro-error = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/examples/async/main.rs
+++ b/examples/async/main.rs
@@ -11,6 +11,6 @@ async fn fac_with_acc(n: u128, acc: u128) -> u128 {
     }
 }
 
-pub fn main(){
+pub fn main() {
     assert_eq!(futures::executor::block_on(fac_with_acc(5, 1)), 120);
 }

--- a/examples/factorial/main.rs
+++ b/examples/factorial/main.rs
@@ -7,6 +7,6 @@ fn fac_with_acc(n: u128, acc: u128) -> u128 {
     }
 }
 
-fn main(){
-    assert_eq!(fac_with_acc(5,1), 120);
+fn main() {
+    assert_eq!(fac_with_acc(5, 1), 120);
 }


### PR DESCRIPTION
The macro now works for functions with 1 argument: When a recursive function call is converted to a tuple with no trailing comma, the comma is added.

This replaces the panics with proper error handling, so the correct spans are highlighted red.

It also applies `cargo fmt`. I suggest to do this automatically when saving a file.